### PR TITLE
Fix path issues on Windows

### DIFF
--- a/lib/edib/build_config/artifact/volume.ex
+++ b/lib/edib/build_config/artifact/volume.ex
@@ -16,7 +16,7 @@ defmodule EDIB.BuildConfig.Artifact.Volume do
 
   defp new(from, to, permissions) do
     %__MODULE__{
-      host_path: from,
+      host_path: sanitize_path(from),
       container_path: to,
       permissions: sanitize_permissions(permissions)
     }
@@ -26,6 +26,13 @@ defmodule EDIB.BuildConfig.Artifact.Volume do
     do: permissions
   defp sanitize_permissions(_),
     do: @default_permissions
+
+  defp sanitize_path(path) do
+    case :os.type() do
+      {:win32, _} -> "/" <> path |> String.replace("\\", "/") |> String.replace(":", "")
+      _ -> path
+    end
+  end
 
   def for_source(host_source_dir) do
     new(


### PR DESCRIPTION
`mix edib` was broken on Windows with an error message like this:

```
mix edib
Will use EDIB tool v1.2.1
==> Packaging your app release into a docker image. Stay tuned!
| $> docker run --rm  -v "c:/Users/markus/project:/source:ro" -v "c:/Users/markus/project/tarballs:/stage/tarballs:rw"  edib/edib-tool:1.2.1
==> Creating artifact (might take a while) ...
| docker: Error response from daemon: Invalid bind mount spec "c:/Users/markus/project:/source:ro": Invalid volume specification: 'c:/Users/markus/project:/source:ro'.
| See 'docker run --help'.
==> An error happened!
==> Reason: Artifact tarball not created! Check for any errors above.
```

The reason is that according to the Docker documentation [1](https://docs.docker.com/engine/userguide/containers/dockervolumes/#mount-a-host-directory-as-a-data-volume), mount directories on should use a Unix-like format: 

> On Windows, mount directories using:
> `docker run -v /c/Users/<path>:/<container path> ...`

This PR fixes this issue. I'm new to Elixir so this might be not idomatic code but I'll gladly take suggestions.
