### PR TITLE
Add deps badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Hex.pm package license](https://img.shields.io/hexpm/l/edib.svg?style=flat-square)](https://github.com/edib-tool/mix-edib/blob/master/LICENSE)
 [![Build Status (master)](https://img.shields.io/travis/edib-tool/mix-edib/master.svg?style=flat-square)](https://travis-ci.org/edib-tool/mix-edib)
 [![Coverage Status (master)](https://img.shields.io/coveralls/edib-tool/mix-edib/master.svg?style=flat-square)](https://coveralls.io/r/edib-tool/mix-edib)
+[![Deps Status](https://beta.hexfaktor.org/badge/all/github/edib-tool/mix-edib.svg?style=flat-square)](https://beta.hexfaktor.org/github/edib-tool/mix-edib)
 [![Inline docs](http://inch-ci.org/github/edib-tool/mix-edib.svg?branch=master&style=flat-square)](http://inch-ci.org/github/edib-tool/mix-edib)
 
 A mix task for [EDIB (elixir docker image builder)](https://github.com/edib-tool/elixir-docker-image-builder).


### PR DESCRIPTION
Hi Christoph,

this PR pitches my latest project for the Elixir community. I realize that it might not be 100% applicable to EDIB since this has no `prod` dependencies, but I will try to pitch it anyway :stuck_out_tongue_closed_eyes: 

[![Deps Status](https://beta.hexfaktor.org/badge/all/github/edib-tool/mix-edib.svg)](https://beta.hexfaktor.org/github/edib-tool/mix-edib) [![Inline docs](http://inch-ci.org/github/edib-tool/mix-edib.svg?branch=master)](http://inch-ci.org/github/edib-tool/mix-edib)

You already know the Inch badge on the right: It shows you an analysis for your Elixir project's docs. The new badge does the same thing for your dependencies.

Behind the badge works a CI service written in Elixir which can notify you whenever important updates for your Hex packages are released.

This is still in its infancy, and I want to basically invite you to join the beta to test-drive this. I really believe that we can create a great service for the community with this. That said, don't feel any obligation to accept the PR, just tell me what you think! :+1:
