### PR TITLE
[EXPERIMENT] Use build_context container

### DIFF
--- a/lib/edib/build_config/artifact/builder.ex
+++ b/lib/edib/build_config/artifact/builder.ex
@@ -10,7 +10,8 @@ defmodule EDIB.BuildConfig.Artifact.Builder do
     |> maybe_artifact_config
     |> set_edib_tool
     |> set_settings
-    |> set_volumes
+    # |> set_volumes # disable all default and custom volumes!
+    |> set_volumes_from
     |> set_priv_flag
     |> set_rm_flag
     |> set_docker_command
@@ -38,6 +39,12 @@ defmodule EDIB.BuildConfig.Artifact.Builder do
     {:ok, config, [Volumes.to_docker_options(volumes) | command_list]}
   end
   defp set_volumes(error), do: error
+
+  defp set_volumes_from({:ok, config, command_list}) do
+    volumes_from = "--volumes-from build_context"
+    {:ok, config, [volumes_from | command_list]}
+  end
+  defp set_volumes_from(error), do: error
 
   defp set_priv_flag({:ok, %{privileged: priv_flag} = config, command_list}) do
     {:ok, config, [ maybe_set_priv_flag(priv_flag) | command_list]}

--- a/lib/edib/runner.ex
+++ b/lib/edib/runner.ex
@@ -23,8 +23,11 @@ defmodule EDIB.Runner do
     |> EDIB.Runner.Check.prerequisites
     |> EDIB.Runner.Log.reinit
     |> package_processing_info
+    |> pre_command
     |> EDIB.Runner.ArtifactBuilder.run
+    |> inter_command
     |> EDIB.Runner.ImageBuilder.run
+    |> post_command
     |> success_or_error!
   end
 
@@ -36,6 +39,23 @@ defmodule EDIB.Runner do
     state
   end
   defp package_processing_info(error), do: error
+
+  def pre_command({_, _, options} = state) do
+    do_cmd("docker rm -f build_context", options.writer)
+    do_cmd("docker create --name build_context --volume /source --volume /stage/tarballs busybox", options.writer)
+    do_cmd("tar -c -C `pwd` . | docker cp - build_context:/source", options.writer)
+    state
+  end
+
+  def inter_command({_, _, options} = state) do
+    do_cmd("docker cp build_context:/stage/tarballs ./tarballs", options.writer)
+    state
+  end
+
+  def post_command({_, _, options}) do
+    do_cmd("docker rm build_context", options.writer)
+    {:ok, :post_command, :end}
+  end
 
   defp success_or_error!({:ok, _, _}) do
     info("Packaging was successful! \\o/")

--- a/lib/edib/runner/image_builder.ex
+++ b/lib/edib/runner/image_builder.ex
@@ -59,7 +59,7 @@ defmodule EDIB.Runner.ImageBuilder do
   defp after_run_command(_, command, state),
     do: {:error, "Image command '#{command}' failed", state}
 
-  defp package_summary({:ok, _msg, {config, _options}}) do
+  defp package_summary({:ok, _msg, {config, options}}) do
     tagged_name = ~s(#{config.name}:#{config.tag})
     latest_name = ~s(#{config.name}:latest)
     info("Docker image created: #{tagged_name} (#{latest_name})")
@@ -76,8 +76,7 @@ defmodule EDIB.Runner.ImageBuilder do
 
     """
     print(usage_info)
-
-    {:ok, :summary, :end}
+    {:ok, :summary, options}
   end
   defp package_summary(error), do: error
 end


### PR DESCRIPTION
Based on findings at https://github.com/edib-tool/mix-edib/issues/10.

**This PR is not intended to be merged, but serves as documentation and playground.**

---

``` sh
# if mix-edib is already installed:
mix archive.uninstall edib-0.8.1
rm -rf _build/dev/lib/edib # because even `mix compile -f` was not always recompiling :-/
mix compile
mix archive.build
mix archive.install edib-0.8.1.ez
```

No custom volume settings are possible (volume setup is skipped in favour of this experiment).
