### PR TITLE
Add support for different environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ Don't forget to add `exrm` to your project:
 
     mix edib
 
+mix-edib will use the MIX_ENV environment variable to build the image.
+
+    MIX_ENV=staging mix edib
+
+**WARNING:** If `MIX_ENV` is not set EDIB will build the image for the `prod` environment.
+
 ## Help
 
     mix help edib

--- a/lib/edib/build_config/artifact/builder.ex
+++ b/lib/edib/build_config/artifact/builder.ex
@@ -9,6 +9,7 @@ defmodule EDIB.BuildConfig.Artifact.Builder do
     artifact_config
     |> maybe_artifact_config
     |> set_edib_tool
+    |> set_environment
     |> set_settings
     |> set_volumes
     |> set_priv_flag
@@ -28,6 +29,13 @@ defmodule EDIB.BuildConfig.Artifact.Builder do
     {:ok, config, [Defaults.edib_tool | command_list]}
   end
   defp set_edib_tool(error), do: error
+
+  defp set_environment({:ok, config, command_list}) do
+    {:ok, config, [environment_setting | command_list]}
+  end
+  defp set_environment(error), do: error
+
+  defp environment_setting, do: "-e #{Defaults.env_variable_name}=#{Defaults.environment}" 
 
   defp set_settings({:ok, %{settings: settings} = config, command_list}) do
     {:ok, config, [ImageSettings.to_docker_options(settings) | command_list]}

--- a/lib/edib/defaults.ex
+++ b/lib/edib/defaults.ex
@@ -5,6 +5,10 @@ defmodule EDIB.Defaults do
   def edib_tool,                  do: "edib/edib-tool:#{edib_version}"
   def tarball_dir_name,           do: "tarballs"
 
+  def env_variable_name,          do: "MIX_ENV"
+  def default_environment,        do: "prod"
+  def environment,                do: System.get_env(env_variable_name) || default_environment
+
   # $HOME should be set, or fallback to a tmp dir:
   def home_dir,                   do: System.user_home || System.tmp_dir
   def current_dir,                do: System.cwd!

--- a/spec/edib/build_config/artifact/builder_spec.exs
+++ b/spec/edib/build_config/artifact/builder_spec.exs
@@ -8,6 +8,7 @@ defmodule EDIBBuildConfigArtifactBuilderSpec do
     describe "build/1" do
       let :rm_flag, do: "--rm"
       let :privileged_flag, do: "--privileged"
+      let :environment_flag, do: "-e MIX_ENV="
 
       context "defaults ('unconfigured' state)" do
         let :default_config, do: %Artifact{}
@@ -18,6 +19,7 @@ defmodule EDIBBuildConfigArtifactBuilderSpec do
           expect(command_string).to have(Defaults.docker_run)
           expect(command_string).to have(rm_flag)
           expect(command_string).to have(Defaults.edib_tool)
+          expect(command_string).to have(environment_flag <> Defaults.environment)
         end
       end
 

--- a/spec/edib/defaults_spec.exs
+++ b/spec/edib/defaults_spec.exs
@@ -21,12 +21,12 @@ defmodule EDIBDefaultsSpec do
 
     describe "environment/0" do
       it "returns prod as default environment" do
-        System.delete_env("MIX_ENV")
+        allow(System |> to(accept :get_env, fn("MIX_ENV") -> nil end))
         expect(Defaults.environment).to eq("prod")
       end
 
       it "returns MIX_ENV as the environment" do
-        System.put_env("MIX_ENV", "staging")
+        allow(System |> to(accept :get_env, fn("MIX_ENV") -> "staging" end))
         expect(Defaults.environment).to eq("staging")
       end
     end

--- a/spec/edib/defaults_spec.exs
+++ b/spec/edib/defaults_spec.exs
@@ -19,6 +19,18 @@ defmodule EDIBDefaultsSpec do
       end
     end
 
+    describe "environment/0" do
+      it "returns prod as default environment" do
+        System.delete_env("MIX_ENV")
+        expect(Defaults.environment).to eq("prod")
+      end
+
+      it "returns MIX_ENV as the environment" do
+        System.put_env("MIX_ENV", "staging")
+        expect(Defaults.environment).to eq("staging")
+      end
+    end
+
     describe "home_dir/0" do
       it "returns the current home directory" do
         expect(Defaults.home_dir).to eql(System.user_home!)


### PR DESCRIPTION
Use MIX_ENV variable to select the build configuration, if it's not set the default is `prod`.

I didn't add anything to the docs because the usage is the same as any other mix task, just set the MIX_ENV. Let me know if you think it's necessary and I'll add. :)

Relates to #13 
